### PR TITLE
Fix errors reference by cloning them

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -10,7 +10,8 @@ function logger(level='error') {
 }
 
 function errors() {
-  return rb.records;
+  // Return a clone of the array so that clear() doesn't clear the result
+  return [...rb.records];
 }
 
 function hasErrors() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The errors returned were a reference to the ringbuffer's records.  As a result, sometimes the test framework would print out the errors -- but they'd no longer be the same errors that caused the test to fail.  Now we clone the errors into a new array before returning them.