### PR TITLE
Implemented sanity checking for conflicting versions of shr-models

### DIFF
--- a/export.js
+++ b/export.js
@@ -307,4 +307,4 @@ function pid(name) {
   return new mdl.PrimitiveIdentifier(name);
 }
 
-module.exports = {commonExportTests};
+module.exports = {commonExportTests, MODELS_INFO: mdl.MODELS_INFO};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
+const export_tests = require('./export');
+
 module.exports = {
   errors: require('./errors'),
-  export: require('./export')
+  export: export_tests,
+  MODELS_INFO: export_tests.MODELS_INFO
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.1.0"
+    "shr-models": "^5.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,9 +881,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
+shr-models@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Added sanity checking support for different versions of `shr-models`. This should be merged and released before the rest of the modules because so many of them depend upon `shr-test-helpers`.