### PR TITLE
Logical models

### DIFF
--- a/export.js
+++ b/export.js
@@ -665,13 +665,13 @@ function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
 function addIncludesCodeConstraints(specs, ns, addSubElements=true) {
   let de = new mdl.DataElement(id(ns, 'IncludesCodesList'), true)
     .withDescription('An entry with a includes codes constraint.')
-    .withValue(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(0)
+    .withValue(new mdl.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar')))
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar')))
     );
   add(specs, de);
   if (addSubElements) {
-    addCodedElement(specs, ns);
+    addCodeableConcept(specs, addSubElements);
   }
   return de;
 }

--- a/export.js
+++ b/export.js
@@ -519,7 +519,7 @@ function addTypeConstrainedElements(specs, ns, otherNS, addSubElements=true) {
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It is a derivative of a group of elements with type constraints.')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'))))
-      .withField(new mdl.IdentifiableValue(id(ns, 'ElementValue')).withMinMax(0).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), undefined, true)))
+      .withField(new mdl.IdentifiableValue(id(ns, 'ElementValue')).withMinMax(0).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), undefined, true)));
   add(specs, gd);
   if (addSubElements) {
     addGroup(specs, ns, otherNS, addSubElements);
@@ -540,15 +540,11 @@ function addTypeConstrainedElementsWithPath(specs, ns, addSubElements=true) {
   let cp = new mdl.DataElement(id(ns, 'ConstrainedPath'), true)
       .withBasedOn(id('shr.test', 'NestedField'))
       .withDescription('It derives an element with a nested field.')
-      .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
+      .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
   let cpni = new mdl.DataElement(id(ns, 'ConstrainedPathNoInheritance'), true)
       .withDescription('It has a new field with a nested constraint.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
-  add(specs, ef);
-  add(specs, td);
-  add(specs, nf);
-  add(specs, cp);
-  add(specs, cpni);
+  add(specs, ef, td, nf, cp, cpni);
   if (addSubElements) {
     addSimpleElement(specs, ns);
     addSimpleChildElement(specs, ns);

--- a/export.js
+++ b/export.js
@@ -255,6 +255,12 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
       checkExpected(expected);
     });
 
+    it('should correctly export nested includes code constraints', function() {
+      addNestedIncludesCodeConstraints(_specs, 'shr.test');
+      const expected = wrappedExpectedFns('NestedIncludesCodeConstraints', this);
+      checkExpected(expected);
+    });
+
     it('should correctly export an element with nested valueset constraints', function() {
       addValueSetConstraints(_specs, 'shr.test', 'shr.other.test');
       const expected = wrappedExpectedFns('NestedValueSetConstraints', this);
@@ -705,6 +711,23 @@ function addIncludesCodeConstraints(specs, ns, addSubElements=true) {
   add(specs, de);
   if (addSubElements) {
     addCodeableConcept(specs, addSubElements);
+  }
+  return de;
+}
+
+function addNestedIncludesCodeConstraints(specs, ns, addSubElements=true) {
+  // NOTE: This tests a suspicious use case, as the includes code resolves to a 1..1 code.  It's the code's parent
+  // that is actually a list -- so the iteration happens one level up.  This test is here because it reflects a real
+  // use case in actual SHR definitions.
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'), true)
+    .withDescription('An entry with a nested includes codes constraint.')
+    .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0)
+      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('code')]))
+      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar'), [pid('code')]))
+    );
+  add(specs, de);
+  if (addSubElements) {
+    addCodedElement(specs, ns);
   }
   return de;
 }

--- a/export.js
+++ b/export.js
@@ -243,6 +243,12 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
       checkExpected(expected);
     });
 
+    it('should correctly export includes type constraints with a zeroed out include type', function() {
+      addIncludesTypeConstraintsWithZeroedOutType(_specs, 'shr.test');
+      const expected = wrappedExpectedFns('IncludesTypeConstraintsZeroedOut', this);
+      checkExpected(expected);
+    });
+
     it('should correctly export includes code constraints', function() {
       addIncludesCodeConstraints(_specs, 'shr.test');
       const expected = wrappedExpectedFns('IncludesCodeConstraints', this);
@@ -612,6 +618,26 @@ function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 2)))
+  );
+  add(specs, sc2);
+  add(specs, de);
+  if (addSubElements) {
+    addSimpleElement(specs, ns);
+    addSimpleChildElement(specs, ns);
+  }
+  return de;
+}
+
+function addIncludesTypeConstraintsWithZeroedOutType(specs, ns, addSubElements=true) {
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+      .withBasedOn(id(ns, 'Simple'))
+      .withDescription('A derivative of the simple type.')
+      .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
+  let de = new mdl.DataElement(id(ns, 'IncludesTypesListWithZeroedOutType'), true)
+      .withDescription('An entry with a includes types constraints.')
+      .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
+          .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
+          .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 0)))
   );
   add(specs, sc2);
   add(specs, de);

--- a/export.js
+++ b/export.js
@@ -220,6 +220,18 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, resultsPath, 
       checkExpected(expected);
     });
 
+    it('should correctly export includes type constraints set on a field\'s value', function() {
+      addOnValueIncludesTypeConstraints(_specs, 'shr.test');
+      const expected = wrappedExpectedFns('OnValueIncludesTypeConstraints', this);
+      checkExpected(expected);
+    });
+
+    it('should correctly export nested includes type constraints', function() {
+      addNestedIncludesTypeConstraints(_specs, 'shr.test');
+      const expected = wrappedExpectedFns('NestedIncludesTypeConstraints', this);
+      checkExpected(expected);
+    });
+
     it('should correctly export includes code constraints', function() {
       addIncludesCodeConstraints(_specs, 'shr.test');
       const expected = wrappedExpectedFns('IncludesCodeConstraints', this);
@@ -596,6 +608,53 @@ function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
   );
   add(specs, sc2);
   add(specs, de);
+  if (addSubElements) {
+    addSimpleElement(specs, ns);
+    addSimpleChildElement(specs, ns);
+  }
+  return de;
+}
+
+function addOnValueIncludesTypeConstraints(specs, ns, addSubElements=true) {
+  let evl = new mdl.DataElement(id(ns, 'ElementValueList'), false, false)
+      .withDescription('It is an element with a value that is a list of elements')
+      .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0));
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+      .withBasedOn(id(ns, 'Simple'))
+      .withDescription('A derivative of the simple type.')
+      .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
+  let de = new mdl.DataElement(id(ns, 'OnValueIncludesTypeConstraints'), true)
+      .withDescription('An entry with includes types constraints that are on the value of the field.')
+      .withField(new mdl.IdentifiableValue(id(ns, 'ElementValueList')).withMinMax(0, 1)
+        .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [], true))
+        .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 2), [], true))
+  );
+  add(specs, evl, sc2, de);
+  if (addSubElements) {
+    addSimpleElement(specs, ns);
+    addSimpleChildElement(specs, ns);
+  }
+  return de;
+}
+
+function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
+  let efl = new mdl.DataElement(id(ns, 'ElementFieldList'), false, false)
+      .withDescription('It is an element with a field that is a list of elements')
+      .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0));
+  let eflc = new mdl.DataElement(id(ns, 'ElementFieldListContainer'), false, false)
+      .withDescription('It is an element with a field that contains an element with a field that is a list of elements')
+      .withField(new mdl.IdentifiableValue(id(ns, 'ElementFieldList')).withMinMax(0,1));
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+      .withBasedOn(id(ns, 'Simple'))
+      .withDescription('A derivative of the simple type.')
+      .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesTypeConstraints'), true)
+      .withDescription('An entry with includes types constraints that are on a nested field.')
+      .withField(new mdl.IdentifiableValue(id(ns, 'ElementFieldListContainer')).withMinMax(0, 1)
+        .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [id(ns, 'ElementFieldList'), id(ns, 'Simple')], false))
+        .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 2), [id(ns, 'ElementFieldList'), id(ns, 'Simple')], false))
+  );
+  add(specs, efl, eflc, sc2, de);
   if (addSubElements) {
     addSimpleElement(specs, ns);
     addSimpleChildElement(specs, ns);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
-    "shr-models": "^5.2.1"
+    "shr-models": "^5.5.0"
   },
   "dependencies": {
     "fs-extra": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
     "shr-models": "^5.2.1"
+  },
+  "dependencies": {
+    "fs-extra": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,14 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -430,7 +438,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -546,6 +554,12 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -852,6 +866,10 @@ type-detect@^1.0.0:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 user-home@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR fixes some bugs in the setup of existing tests, adds new tests, and adds two new features:
- Write the actual results to a specified folder.  This can be helpful when debugging failing tests.
- Auto-fix broken tests by overwriting the broken fixture with the actual result.  This is helpful when tests are expected to be broken due to new features / changes, and you want to update the fixtures to represent the new output.

See the shr-fhir-export logical models tests for examples.

Note that because some existing tests were updating (to fix real problems in the tests), some existing projects may fail when running against this new version.  It's recommended that projects only upgrade to this version after testing and fixing any discrepencies.