### PR TITLE
v5.2.2 (remove mistakenly added dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -24,7 +24,6 @@
     "shr-models": "^5.5.0"
   },
   "dependencies": {
-    "fs-extra": "^5.0.0",
-    "shr-models": "^5.5.3"
+    "fs-extra": "^5.0.0"
   }
 }


### PR DESCRIPTION
shr-models was mistakenly added as a dependency when it should only be a peerDependency.  This has been fixed.