### PR TITLE
CIMPL6 Import

### DIFF
--- a/export.js
+++ b/export.js
@@ -279,7 +279,7 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
       checkExpected(expected);
     });
 
-    it('should correctly export an element with code/Coding/CodeableConcept constraints', function() {
+    it('should correctly export an element with code constraints', function() {
       addFixedCodeExtravaganza(_specs, 'shr.test');
       const expected = wrappedExpectedFns('FixedCodeExtravaganza', this);
       checkExpected(expected);
@@ -365,7 +365,7 @@ function addSimpleElement(specs, ns) {
 function addCodedElement(specs, ns) {
   let de = new mdl.DataElement(id(ns, 'Coded'), true)
     .withDescription('It is a coded element')
-    .withValue(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1)
+    .withValue(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
       .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded'))
     );
   add(specs, de);
@@ -427,7 +427,7 @@ function addChoice(specs, ns, addSubElements=true) {
     .withDescription('It is an element with a choice')
     .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
       .withOption(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1))
-      .withOption(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1)
+      .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
         .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/CodeChoice'))
       )
       .withOption(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(1, 1))
@@ -448,7 +448,7 @@ function addChoiceOfChoice(specs, ns) {
         .withOption(new mdl.IdentifiableValue(pid('integer')).withMinMax(1, 1))
         .withOption(new mdl.IdentifiableValue(pid('decimal')).withMinMax(1, 1))
       )
-      .withOption(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1)
+      .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
         .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/CodeChoice'))
       )
     );
@@ -701,17 +701,14 @@ function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
   return de;
 }
 
-function addIncludesCodeConstraints(specs, ns, addSubElements=true) {
+function addIncludesCodeConstraints(specs, ns) {
   let de = new mdl.DataElement(id(ns, 'IncludesCodesList'), true)
     .withDescription('An entry with a includes codes constraint.')
-    .withValue(new mdl.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0)
+    .withValue(new mdl.IdentifiableValue(pid('concept')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar')))
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar')))
     );
   add(specs, de);
-  if (addSubElements) {
-    addCodeableConcept(specs, addSubElements);
-  }
   return de;
 }
 
@@ -722,8 +719,8 @@ function addNestedIncludesCodeConstraints(specs, ns, addSubElements=true) {
   let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'), true)
     .withDescription('An entry with a nested includes codes constraint.')
     .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0)
-      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('code')]))
-      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar'), [pid('code')]))
+      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('concept')]))
+      .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar'), [pid('concept')]))
     );
   add(specs, de);
   if (addSubElements) {
@@ -737,7 +734,7 @@ function addValueSetConstraints(specs, ns, otherNS, addSubElements=true) {
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It has valueset constraints on a field.')
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0, 1)
-        .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('code')]).withBindingStrength(mdl.REQUIRED))
+        .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('concept')]).withBindingStrength(mdl.REQUIRED))
   );
   add(specs, gd);
   if (addSubElements) {
@@ -751,12 +748,12 @@ function addValueSetChoiceConstraints(specs, ns, addSubElements=true) {
     .withDescription('An element with a choice of code fields.')
     .withValue(new mdl.ChoiceValue().withMinMax(0, 1)
       .withOption(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1))
-      .withOption(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1))
+      .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1))
     );
   let de = new mdl.DataElement(id(ns, 'ChoiceValueSetConstraint'), true)
     .withDescription('It has valueset constraints on a choice field.')
     .withField(new mdl.IdentifiableValue(id(ns, 'CodedChoice')).withMinMax(0, 1)
-      .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('code')]).withBindingStrength(mdl.PREFERRED))
+      .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('concept')]).withBindingStrength(mdl.PREFERRED))
     );
   add(specs, cc, de);
   if (addSubElements) {
@@ -774,7 +771,7 @@ function addConstConstraints(specs, ns, otherNS, addSubElements=true) {
     .withDescription('It has boolean and code constraints.')
     .withValue(new mdl.IdentifiableValue(pid('boolean')).withMinMax(1, 1).withConstraint(new mdl.BooleanConstraint(true)))
     .withField(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(0, 1)
-      .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('code')])))
+      .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('concept')])))
     .withField(new mdl.IdentifiableValue(id(ns, 'Bool')).withMinMax(0, 1)
       .withConstraint(new mdl.BooleanConstraint(false)));
 
@@ -786,55 +783,28 @@ function addConstConstraints(specs, ns, otherNS, addSubElements=true) {
 }
 
 function addFixedCodeExtravaganza(specs, ns, addSubElements=true) {
+  // NOTE: This is considerably less interesting w/ the elimination of Coding and CodeableConcept
   const fce = new mdl.DataElement(id(ns, 'FixedCodeExtravaganza'), false, false)
     .withDescription('An element with all sorts of fixed codes.')
     .withValue(new mdl.ChoiceValue().withMinMax(0, 1)
-      .withOption(new mdl.IdentifiableValue(pid('code')).withMinMax(1, 1)
-        .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo1.org', 'bar1', 'Foobar1')))
+      .withOption(new mdl.IdentifiableValue(pid('Coded')).withMinMax(1, 1)
+        .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo1.org', 'bar1', 'Foobar1'), [pid('concept')]))
       )
-      .withOption(new mdl.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1, 1)
+      .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
         .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo2.org', 'bar2', 'Foobar2')))
       )
     )
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(1, 1)
+    .withField(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
       .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo3.org', 'bar3', 'Foobar3')))
     )
     .withField(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1)
-      .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo4.org', 'bar4', 'Foobar4'), [pid('code')]))
+      .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo4.org', 'bar4', 'Foobar4'), [pid('concept')]))
     );
   add(specs, fce);
   if (addSubElements) {
     addCodedElement(specs, ns);
-    addCodeableConcept(specs, addSubElements);
   }
 
-}
-
-function addCodeableConcept(specs, addSubElements=true) {
-  const cc = new mdl.DataElement(id('shr.core', 'CodeableConcept'), false, false)
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0))
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'DisplayText')).withMinMax(0, 1));
-  add(specs, cc);
-  if (addSubElements) {
-    addCoding(specs);
-  }
-  return cc;
-}
-
-function addCoding(specs) {
-  const coding = new mdl.DataElement(id('shr.core', 'Coding'), false, false)
-    .withValue(new mdl.IdentifiableValue(pid('code')).withMinMax(0, 1))
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'CodeSystem')).withMinMax(0, 1))
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'CodeSystemVersion')).withMinMax(0, 1))
-    .withField(new mdl.IdentifiableValue(id('shr.core', 'DisplayText')).withMinMax(0, 1));
-  const codeSystem = new mdl.DataElement(id('shr.core', 'CodeSystem'), false, false)
-    .withValue(new mdl.IdentifiableValue(pid('uri')).withMinMax(1, 1));
-  const codeSystemVersion = new mdl.DataElement(id('shr.core', 'CodeSystemVersion'), false, false)
-    .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  const displayText = new mdl.DataElement(id('shr.core', 'DisplayText'), false, false)
-    .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  add(specs, coding, codeSystem, codeSystemVersion, displayText);
-  return coding;
 }
 
 function addSimpleChildElement(specs, ns) {

--- a/export.js
+++ b/export.js
@@ -288,7 +288,7 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
 }
 
 function addGroup(specs, ns, otherNS, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'Group'), true)
+  let gr = new mdl.DataElement(id(ns, 'Group'))
     .withDescription('It is a group of elements')
     .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
     .withConcept(new mdl.Concept('http://boo.org', 'far', 'Boofar'))
@@ -307,7 +307,7 @@ function addGroup(specs, ns, otherNS, addSubElements=true) {
 }
 
 function addGroupWithChoiceOfChoice(specs, ns, otherNS, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'GroupWithChoiceOfChoice'), true)
+  let gr = new mdl.DataElement(id(ns, 'GroupWithChoiceOfChoice'))
     .withValue(new mdl.ChoiceValue().withMinMax(0,2)
       .withOption(new mdl.IdentifiableValue(id('shr.other.test', 'Simple')).withMinMax(1, 1))
       .withOption(new mdl.ChoiceValue().withMinMax(1, 1)
@@ -329,7 +329,7 @@ function addGroupWithChoiceOfChoice(specs, ns, otherNS, addSubElements=true) {
 }
 
 function addGroupPathClash(specs, ns, nsOther, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'GroupPathClash'), true)
+  let gr = new mdl.DataElement(id(ns, 'GroupPathClash'))
     .withDescription('It is a group of elements with clashing names')
     .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1))
     .withField(new mdl.IdentifiableValue(id('shr.other.test', 'Simple')).withMinMax(0, 1));
@@ -342,7 +342,7 @@ function addGroupPathClash(specs, ns, nsOther, addSubElements=true) {
 }
 
 function addGroupDerivative(specs, ns, otherNS, addSubElements=true) {
-  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'), true)
+  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'))
     .withBasedOn(id('shr.test', 'Group'))
     .withDescription('It is a derivative of a group of elements')
     .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
@@ -353,8 +353,8 @@ function addGroupDerivative(specs, ns, otherNS, addSubElements=true) {
   return gd;
 }
 
-function addSimpleElement(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'Simple'), true)
+function addSimpleElement(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'Simple'), isEntry)
     .withDescription('It is a simple element')
     .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
     .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
@@ -362,8 +362,12 @@ function addSimpleElement(specs, ns) {
   return de;
 }
 
-function addCodedElement(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'Coded'), true)
+function addSimpleEntry(specs, ns) {
+  return addSimpleElement(specs, ns, true);
+}
+
+function addCodedElement(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'Coded'), isEntry)
     .withDescription('It is a coded element')
     .withValue(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1)
       .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded'))
@@ -372,27 +376,38 @@ function addCodedElement(specs, ns) {
   return de;
 }
 
-function addSimpleReference(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'SimpleReference'), true)
+function addCodedEntry(specs, ns) {
+  return addCodedElement(specs, ns, true);
+}
+
+function addSimpleReference(specs, ns, addSubElement=true) {
+  let de = new mdl.DataElement(id(ns, 'SimpleReference'))
     .withDescription('It is a reference to a simple element')
-    .withValue(new mdl.RefValue(id(ns, 'Simple')).withMinMax(1, 1));
+    .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1)); // Reference to Entry
   add(specs, de);
+  if (addSubElement) {
+    addSimpleEntry(specs, ns);
+  }
   return de;
 }
 
-function addReferenceChoice(specs, ns, otherNS) {
-  let ch = new mdl.DataElement(id(ns, 'ReferenceChoice'), true)
+function addReferenceChoice(specs, ns, otherNS, addSubElement=true) {
+  let ch = new mdl.DataElement(id(ns, 'ReferenceChoice'))
       .withDescription('It is a reference to one of a few types')
       .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
-          .withOption(new mdl.RefValue(id(otherNS, 'Simple')).withMinMax(1, 1))
-          .withOption(new mdl.RefValue(id(ns, 'Coded')).withMinMax(1, 1))
+          .withOption(new mdl.IdentifiableValue(id(otherNS, 'Simple')).withMinMax(1, 1)) // Reference to Entry
+          .withOption(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1)) // Reference to Entry
       );
   add(specs, ch);
+  if (addSubElement) {
+    addSimpleEntry(specs, otherNS);
+    addCodedEntry(specs, ns);
+  }
   return ch;
 }
 
 function addTwoDeepElementValue(specs, ns, addSubElement=true) {
-  let de = new mdl.DataElement(id(ns, 'TwoDeepElementValue'), true)
+  let de = new mdl.DataElement(id(ns, 'TwoDeepElementValue'))
     .withDescription('It is an element with a two-deep element value')
     .withValue(new mdl.IdentifiableValue(id(ns, 'ElementValue')).withMinMax(1, 1));
   add(specs, de);
@@ -403,7 +418,7 @@ function addTwoDeepElementValue(specs, ns, addSubElement=true) {
 }
 
 function addElementValue(specs, ns, addSubElement=true) {
-  let de = new mdl.DataElement(id(ns, 'ElementValue'), true)
+  let de = new mdl.DataElement(id(ns, 'ElementValue'))
     .withDescription('It is an element with an element value')
     .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1));
   add(specs, de);
@@ -414,7 +429,7 @@ function addElementValue(specs, ns, addSubElement=true) {
 }
 
 function addForeignElementValue(specs, ns, otherNS) {
-  let de = new mdl.DataElement(id(ns, 'ForeignElementValue'), true)
+  let de = new mdl.DataElement(id(ns, 'ForeignElementValue'))
     .withDescription('It is an element with a foreign element value')
     .withValue(new mdl.IdentifiableValue(id(otherNS, 'Simple')).withMinMax(1, 1));
   add(specs, de);
@@ -423,7 +438,7 @@ function addForeignElementValue(specs, ns, otherNS) {
 }
 
 function addChoice(specs, ns, addSubElements=true) {
-  let ch = new mdl.DataElement(id(ns, 'Choice'), true)
+  let ch = new mdl.DataElement(id(ns, 'Choice'))
     .withDescription('It is an element with a choice')
     .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
       .withOption(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1))
@@ -440,7 +455,7 @@ function addChoice(specs, ns, addSubElements=true) {
 }
 
 function addChoiceOfChoice(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'ChoiceOfChoice'), true)
+  let de = new mdl.DataElement(id(ns, 'ChoiceOfChoice'))
     .withDescription('It is an element with a choice containing a choice')
     .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
       .withOption(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1))
@@ -457,7 +472,7 @@ function addChoiceOfChoice(specs, ns) {
 }
 
 function addTBDElement(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'NotDone'), true)
+  let de = new mdl.DataElement(id(ns, 'NotDone'))
       .withDescription('It is an unfinished element')
       .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
       .withValue(new mdl.TBD('An undetermined value.').withMinMax(1, 1))
@@ -469,7 +484,7 @@ function addTBDElement(specs, ns) {
 }
 
 function addTBDElementDerivative(specs, ns, addSubElements=true) {
-  let de = new mdl.DataElement(id(ns, 'NotDoneDerivative'), true)
+  let de = new mdl.DataElement(id(ns, 'NotDoneDerivative'))
       .withBasedOn(new mdl.TBD('An undetermined parent.'))
       .withBasedOn(new mdl.TBD())
       .withBasedOn(id('shr.test', 'ValuelessElement'))
@@ -479,7 +494,7 @@ function addTBDElementDerivative(specs, ns, addSubElements=true) {
       .withField(new mdl.TBD('An undetermined singular field.').withMinMax(1, 1));
   add(specs, de);
   if (addSubElements) {
-    add(specs, new mdl.DataElement(id(ns, 'ValuelessElement'), true)
+    add(specs, new mdl.DataElement(id(ns, 'ValuelessElement'))
         .withDescription('An element with no value.')
         .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1)));
     addSimpleElement(specs, ns);
@@ -488,7 +503,7 @@ function addTBDElementDerivative(specs, ns, addSubElements=true) {
 }
 
 function addAbstractAndPlainElements(specs, ns, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'AbstractAndPlainGroup'), true, true)
+  let gr = new mdl.DataElement(id(ns, 'AbstractAndPlainGroup'), false, true)
       .withDescription('It is an abstract group of elements')
       .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1))
@@ -511,7 +526,7 @@ function addNestedCardConstrainedElement(specs, ns, addSubElements=true) {
   let of = new mdl.DataElement(id(ns, 'OptionalField'))
     .withDescription('An element with an optional field.')
     .withField(new mdl.IdentifiableValue(id(ns, 'OptionalValue')).withMinMax(0, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedCardConstraint'), true)
+  let de = new mdl.DataElement(id(ns, 'NestedCardConstraint'))
       .withDescription('It has a field with a nested card constraint.')
       .withField(new mdl.IdentifiableValue(id(ns, 'OptionalField'))
         .withMinMax(1, 1)
@@ -527,7 +542,7 @@ function addNestedListCardConstrainedElements(specs, ns, addSubElements=true) {
   let of = new mdl.DataElement(id(ns, 'ListField'))
       .withDescription('An element with a list field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'OptionalList')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedListCardConstraints'), true)
+  let de = new mdl.DataElement(id(ns, 'NestedListCardConstraints'))
       .withDescription('It has a field with a nested card constraint on a list.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ListField'))
           .withMinMax(1, 1)
@@ -538,7 +553,7 @@ function addNestedListCardConstrainedElements(specs, ns, addSubElements=true) {
 
 function addTypeConstrainedElements(specs, ns, otherNS, addSubElements=true) {
   addSimpleChildElement(specs, ns);
-  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'), true)
+  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'))
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It is a derivative of a group of elements with type constraints.')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'))))
@@ -551,20 +566,20 @@ function addTypeConstrainedElements(specs, ns, otherNS, addSubElements=true) {
 }
 
 function addTypeConstrainedElementsWithPath(specs, ns, addSubElements=true) {
-  let ef = new mdl.DataElement(id(ns, 'ElementField'), true)
+  let ef = new mdl.DataElement(id(ns, 'ElementField'))
       .withDescription('It is an element with a field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1));
-  let td = new mdl.DataElement(id(ns, 'TwoDeepElementField'), true)
+  let td = new mdl.DataElement(id(ns, 'TwoDeepElementField'))
       .withDescription('It is an element with a two-deep element field')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementField')).withMinMax(1, 1));
-  let nf = new mdl.DataElement(id(ns, 'NestedField'), true)
+  let nf = new mdl.DataElement(id(ns, 'NestedField'))
       .withDescription('It is an element with a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1));
-  let cp = new mdl.DataElement(id(ns, 'ConstrainedPath'), true)
+  let cp = new mdl.DataElement(id(ns, 'ConstrainedPath'))
       .withBasedOn(id('shr.test', 'NestedField'))
       .withDescription('It derives an element with a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
-  let cpni = new mdl.DataElement(id(ns, 'ConstrainedPathNoInheritance'), true)
+  let cpni = new mdl.DataElement(id(ns, 'ConstrainedPathNoInheritance'))
       .withDescription('It has a new field with a nested constraint.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
   add(specs, ef, td, nf, cp, cpni);
@@ -576,18 +591,18 @@ function addTypeConstrainedElementsWithPath(specs, ns, addSubElements=true) {
 }
 
 function addTypeConstrainedChoices(specs, ns, addSubElements=true) {
-  let tcc = new mdl.DataElement(id(ns, 'TypeConstrainedChoice'), true)
+  let tcc = new mdl.DataElement(id(ns, 'TypeConstrainedChoice'))
     .withDescription('It is an element with a choice with a constraint.')
     .withField(new mdl.IdentifiableValue(id(ns, 'Choice')).withMinMax(1, 1)
       .withConstraint(new mdl.TypeConstraint(pid('string')).withOnValue(true))
     );
-  let cv = new mdl.DataElement(id(ns, 'ChoiceValue'), true)
+  let cv = new mdl.DataElement(id(ns, 'ChoiceValue'))
     .withDescription('It is an element with a choice value.')
     .withValue(new mdl.IdentifiableValue(id(ns, 'Choice')).withMinMax(1, 1));
-  let td = new mdl.DataElement(id(ns, 'TwoDeepChoiceField'), true)
+  let td = new mdl.DataElement(id(ns, 'TwoDeepChoiceField'))
     .withDescription('It is an element with a a field with a choice.')
     .withField(new mdl.IdentifiableValue(id(ns, 'ChoiceValue')).withMinMax(0, 1));
-  let tccp = new mdl.DataElement(id(ns, 'TypeConstrainedChoiceWithPath'), true)
+  let tccp = new mdl.DataElement(id(ns, 'TypeConstrainedChoiceWithPath'))
     .withDescription('It is an element with a choice on a field with a constraint.')
     .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepChoiceField')).withMinMax(0, 1)
       .withConstraint(new mdl.TypeConstraint(id(ns, 'Coded'), [id(ns, 'ChoiceValue'), id(ns, 'Choice')], true))
@@ -600,26 +615,26 @@ function addTypeConstrainedChoices(specs, ns, addSubElements=true) {
 }
 
 function addTypeConstrainedReference(specs, ns, addSubElements=true) {
-  let de = new mdl.DataElement(id(ns, 'TypeConstrainedReference'), true)
+  let de = new mdl.DataElement(id(ns, 'TypeConstrainedReference'))
     .withBasedOn(id(ns, 'SimpleReference'))
     .withDescription('It is an element a constraint on a reference.')
-    .withValue(new mdl.RefValue(id(ns, 'Simple')).withMinMax(1, 1)
+    .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1) // Reference to Entry
       .withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'))));
   add(specs, de);
   if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
+    addSimpleEntry(specs, ns);
+    addSimpleChildEntry(specs, ns);
     addSimpleReference(specs, ns);
   }
   return de;
 }
 
 function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
-  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'IncludesTypesList'), true)
+  let de = new mdl.DataElement(id(ns, 'IncludesTypesList'))
       .withDescription('An entry with a includes types constraints.')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
@@ -635,11 +650,11 @@ function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
 }
 
 function addIncludesTypeConstraintsWithZeroedOutType(specs, ns, addSubElements=true) {
-  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'IncludesTypesListWithZeroedOutType'), true)
+  let de = new mdl.DataElement(id(ns, 'IncludesTypesListWithZeroedOutType'))
       .withDescription('An entry with a includes types constraints.')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
@@ -658,11 +673,11 @@ function addOnValueIncludesTypeConstraints(specs, ns, addSubElements=true) {
   let evl = new mdl.DataElement(id(ns, 'ElementValueList'), false, false)
       .withDescription('It is an element with a value that is a list of elements')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0));
-  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'OnValueIncludesTypeConstraints'), true)
+  let de = new mdl.DataElement(id(ns, 'OnValueIncludesTypeConstraints'))
       .withDescription('An entry with includes types constraints that are on the value of the field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementValueList')).withMinMax(0, 1)
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [], true))
@@ -683,11 +698,11 @@ function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
   let eflc = new mdl.DataElement(id(ns, 'ElementFieldListContainer'), false, false)
       .withDescription('It is an element with a field that contains an element with a field that is a list of elements')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementFieldList')).withMinMax(0,1));
-  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'), true)
+  let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedIncludesTypeConstraints'), true)
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesTypeConstraints'))
       .withDescription('An entry with includes types constraints that are on a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementFieldListContainer')).withMinMax(0, 1)
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [id(ns, 'ElementFieldList'), id(ns, 'Simple')], false))
@@ -702,7 +717,7 @@ function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
 }
 
 function addIncludesCodeConstraints(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'IncludesCodesList'), true)
+  let de = new mdl.DataElement(id(ns, 'IncludesCodesList'))
     .withDescription('An entry with a includes codes constraint.')
     .withValue(new mdl.IdentifiableValue(pid('concept')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar')))
@@ -716,7 +731,7 @@ function addNestedIncludesCodeConstraints(specs, ns, addSubElements=true) {
   // NOTE: This tests a suspicious use case, as the includes code resolves to a 1..1 code.  It's the code's parent
   // that is actually a list -- so the iteration happens one level up.  This test is here because it reflects a real
   // use case in actual SHR definitions.
-  let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'), true)
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'))
     .withDescription('An entry with a nested includes codes constraint.')
     .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('concept')]))
@@ -730,7 +745,7 @@ function addNestedIncludesCodeConstraints(specs, ns, addSubElements=true) {
 }
 
 function addValueSetConstraints(specs, ns, otherNS, addSubElements=true) {
-  let gd = new mdl.DataElement(id(ns, 'NestedValueSetConstraints'), true)
+  let gd = new mdl.DataElement(id(ns, 'NestedValueSetConstraints'))
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It has valueset constraints on a field.')
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0, 1)
@@ -744,13 +759,13 @@ function addValueSetConstraints(specs, ns, otherNS, addSubElements=true) {
 }
 
 function addValueSetChoiceConstraints(specs, ns, addSubElements=true) {
-  let cc = new mdl.DataElement(id(ns, 'CodedChoice'), true)
+  let cc = new mdl.DataElement(id(ns, 'CodedChoice'))
     .withDescription('An element with a choice of code fields.')
     .withValue(new mdl.ChoiceValue().withMinMax(0, 1)
       .withOption(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1))
       .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1))
     );
-  let de = new mdl.DataElement(id(ns, 'ChoiceValueSetConstraint'), true)
+  let de = new mdl.DataElement(id(ns, 'ChoiceValueSetConstraint'))
     .withDescription('It has valueset constraints on a choice field.')
     .withField(new mdl.IdentifiableValue(id(ns, 'CodedChoice')).withMinMax(0, 1)
       .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('concept')]).withBindingStrength(mdl.PREFERRED))
@@ -766,7 +781,7 @@ function addConstConstraints(specs, ns, otherNS, addSubElements=true) {
   let bl = new mdl.DataElement(id(ns, 'Bool'), false)
     .withDescription('A boolean element.')
       .withValue(new mdl.IdentifiableValue(pid('boolean')).withMinMax(0, 1));
-  let cc = new mdl.DataElement(id(ns, 'BooleanAndCodeConstraints'), true)
+  let cc = new mdl.DataElement(id(ns, 'BooleanAndCodeConstraints'))
     .withBasedOn(id('shr.test', 'Group'))
     .withDescription('It has boolean and code constraints.')
     .withValue(new mdl.IdentifiableValue(pid('boolean')).withMinMax(1, 1).withConstraint(new mdl.BooleanConstraint(true)))
@@ -807,12 +822,16 @@ function addFixedCodeExtravaganza(specs, ns, addSubElements=true) {
 
 }
 
-function addSimpleChildElement(specs, ns) {
-  let sc1 = new mdl.DataElement(id(ns, 'SimpleChild'), true)
+function addSimpleChildElement(specs, ns, isEntry=false) {
+  let sc1 = new mdl.DataElement(id(ns, 'SimpleChild'), isEntry)
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
   add(specs, sc1);
+}
+
+function addSimpleChildEntry(specs, ns) {
+  addSimpleChildElement(specs, ns, true);
 }
 
 function add(specs, ...dataElements) {

--- a/export.js
+++ b/export.js
@@ -49,8 +49,10 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
       } catch (ex) {
         if (err.errors().length) {
           console.error('Test failed, additional errors that occurred while executing the test are', err.errors());
+          if (resultsPath) {
             fs.writeFileSync(path.join(resultsPath, `${expected.name}_errors.json`), JSON.stringify(err.errors(), null, 2));
           }
+        }
         if (typeof fixFn === 'function') {
           fixFn(expected.name, result, err.errors());
         }

--- a/export.js
+++ b/export.js
@@ -49,8 +49,8 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
       } catch (ex) {
         if (err.errors().length) {
           console.error('Test failed, additional errors that occurred while executing the test are', err.errors());
-          fs.writeFileSync(path.join(resultsPath, `${expected.name}_errors.json`), JSON.stringify(err.errors(), null, 2));
-        }
+            fs.writeFileSync(path.join(resultsPath, `${expected.name}_errors.json`), JSON.stringify(err.errors(), null, 2));
+          }
         if (typeof fixFn === 'function') {
           fixFn(expected.name, result, err.errors());
         }
@@ -90,205 +90,205 @@ function commonExportTests(exportFn, expectedFn, expectedErrorsFn, fixFn, result
     });
 
     it('should correctly export a simple entry', function() {
-      addSimpleElement(_specs, 'shr.test');
+      addSimpleElement(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('Simple', this);
       checkExpected(expected);
     });
 
     it('should correctly export a simple entry in a different namespace', function() {
-      addSimpleElement(_specs, 'shr.other.test');
+      addSimpleElement(_specs, 'shr.other.test', true);
       const expected = wrappedExpectedFns('ForeignSimple', this);
       checkExpected(expected);
     });
 
     it('should correctly export a coded entry', function() {
-      addCodedElement(_specs, 'shr.test');
+      addCodedElement(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('Coded', this);
       checkExpected(expected);
     });
 
     it('should correctly export a reference entry', function() {
-      addSimpleReference(_specs, 'shr.test');
+      addSimpleReference(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('SimpleReference', this);
       checkExpected(expected);
     });
 
     it('should correctly export a choice of references', function() {
-      addReferenceChoice(_specs, 'shr.test', 'shr.other.test');
+      addReferenceChoice(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('ReferenceChoice', this);
       checkExpected(expected);
     });
 
     it('should correctly export an entry with an element value', function() {
       // NOTE: This is an entry where the value is not a primitive, e.g. "Value: SomeOtherDataElement"
-      addElementValue(_specs, 'shr.test');
+      addElementValue(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('ElementValue', this);
       checkExpected(expected);
     });
 
     it('should correctly export an entry with an element value in a different namespace', function() {
       // NOTE: This is an entry where the value is not a primitive, e.g. "Value: SomeOtherDataElement"
-      addForeignElementValue(_specs, 'shr.test', 'shr.other.test');
+      addForeignElementValue(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('ForeignElementValue', this);
       checkExpected(expected);
     });
 
     it('should correctly export an entry with two-deep element value', function() {
       // NOTE: This is an entry where the value is a non-primitive, that itself has a value that is a non-primitive
-      addTwoDeepElementValue(_specs, 'shr.test');
+      addTwoDeepElementValue(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('TwoDeepElementValue', this);
       checkExpected(expected);
     });
 
     it('should correctly export a choice', function() {
-      addChoice(_specs, 'shr.test');
+      addChoice(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('Choice', this);
       checkExpected(expected);
     });
 
     it('should correctly export a choice containing a choice', function() {
-      addChoiceOfChoice(_specs, 'shr.test');
+      addChoiceOfChoice(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('ChoiceOfChoice', this);
       checkExpected(expected);
     });
 
     it('should correctly export a group', function() {
-      addGroup(_specs, 'shr.test', 'shr.other.test');
+      addGroup(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('Group', this);
       checkExpected(expected);
     });
 
     it('should correctly export a group with a choice containing a choice', function() {
-      addGroupWithChoiceOfChoice(_specs, 'shr.test', 'shr.other.test');
+      addGroupWithChoiceOfChoice(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('GroupWithChoiceOfChoice', this);
       checkExpected(expected);
     });
 
     it('should correctly export a group with name clashes', function() {
-      addGroupPathClash(_specs, 'shr.test', 'shr.other.test');
+      addGroupPathClash(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('GroupPathClash', this);
       checkExpected(expected);
     });
 
     it('should correctly export an element based on a group element', function() {
-      addGroupDerivative(_specs, 'shr.test', 'shr.other.test');
+      addGroupDerivative(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('GroupDerivative', this);
       checkExpected(expected);
     });
 
     it('tbd value and fields', function() {
-      addTBDElement(_specs, 'shr.test');
+      addTBDElement(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NotDone', this);
       checkExpected(expected);
     });
 
     it('tbd inheritance', function() {
-      addTBDElementDerivative(_specs, 'shr.test');
+      addTBDElementDerivative(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NotDoneDerivative', this);
       checkExpected(expected);
     });
 
     it('abstract and non-entry elements', function() {
-      addAbstractAndPlainElements(_specs, 'shr.test');
+      addAbstractAndPlainElements(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('AbstractAndPlainGroup', this);
       checkExpected(expected);
     });
 
     it('should correctly export elements with nested cardinality constraints', function() {
-      addNestedCardConstrainedElement(_specs, 'shr.test');
+      addNestedCardConstrainedElement(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NestedCardConstraint', this);
       checkExpected(expected);
     });
     it('should correctly export elements with nested cardinality constraints on lists', function() {
-      addNestedListCardConstrainedElements(_specs, 'shr.test');
+      addNestedListCardConstrainedElements(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NestedListCardConstraints', this);
       checkExpected(expected);
     });
     it('should correctly export elements with type constraints', function() {
-      addTypeConstrainedElements(_specs, 'shr.test', 'shr.other.test');
+      addTypeConstrainedElements(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('TypeConstraints', this);
       checkExpected(expected);
     });
     it('should correctly export nested elements with type constraints', function() {
-      addTypeConstrainedElementsWithPath(_specs, 'shr.test');
+      addTypeConstrainedElementsWithPath(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('TypeConstraintsWithPath', this);
       checkExpected(expected);
     });
     it('should correctly export choices with type constraints', function() {
-      addTypeConstrainedChoices(_specs, 'shr.test');
+      addTypeConstrainedChoices(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('TypeConstrainedChoices', this);
       checkExpected(expected);
     });
     it('should correctly export type constraints on references', function() {
-      addTypeConstrainedReference(_specs, 'shr.test');
+      addTypeConstrainedReference(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('TypeConstrainedReference', this);
       checkExpected(expected);
     });
 
     it('should correctly export includes type constraints', function() {
-      addIncludesTypeConstraints(_specs, 'shr.test');
+      addIncludesTypeConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('IncludesTypeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export includes type constraints set on a field\'s value', function() {
-      addOnValueIncludesTypeConstraints(_specs, 'shr.test');
+      addOnValueIncludesTypeConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('OnValueIncludesTypeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export nested includes type constraints', function() {
-      addNestedIncludesTypeConstraints(_specs, 'shr.test');
+      addNestedIncludesTypeConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NestedIncludesTypeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export includes type constraints with a zeroed out include type', function() {
-      addIncludesTypeConstraintsWithZeroedOutType(_specs, 'shr.test');
+      addIncludesTypeConstraintsWithZeroedOutType(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('IncludesTypeConstraintsZeroedOut', this);
       checkExpected(expected);
     });
 
     it('should correctly export includes code constraints', function() {
-      addIncludesCodeConstraints(_specs, 'shr.test');
+      addIncludesCodeConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('IncludesCodeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export nested includes code constraints', function() {
-      addNestedIncludesCodeConstraints(_specs, 'shr.test');
+      addNestedIncludesCodeConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('NestedIncludesCodeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export an element with nested valueset constraints', function() {
-      addValueSetConstraints(_specs, 'shr.test', 'shr.other.test');
+      addValueSetConstraints(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('NestedValueSetConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export an element with valueset constraints on a choice', function() {
-      addValueSetChoiceConstraints(_specs, 'shr.test');
+      addValueSetChoiceConstraints(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('ChoiceValueSetConstraint', this);
       checkExpected(expected);
     });
 
     it('should correctly export an element with boolean and code constraints', function() {
-      addConstConstraints(_specs, 'shr.test', 'shr.other.test');
+      addConstConstraints(_specs, 'shr.test', 'shr.other.test', true);
       const expected = wrappedExpectedFns('BooleanAndCodeConstraints', this);
       checkExpected(expected);
     });
 
     it('should correctly export an element with code constraints', function() {
-      addFixedCodeExtravaganza(_specs, 'shr.test');
+      addFixedCodeExtravaganza(_specs, 'shr.test', true);
       const expected = wrappedExpectedFns('FixedCodeExtravaganza', this);
       checkExpected(expected);
     });
   };
 }
 
-function addGroup(specs, ns, otherNS, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'Group'))
+function addGroup(specs, ns, otherNS, isEntry=false) {
+  let gr = new mdl.DataElement(id(ns, 'Group'), isEntry)
     .withDescription('It is a group of elements')
     .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
     .withConcept(new mdl.Concept('http://boo.org', 'far', 'Boofar'))
@@ -296,18 +296,17 @@ function addGroup(specs, ns, otherNS, addSubElements=true) {
     .withField(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0, 1))
     .withField(new mdl.IdentifiableValue(id('shr.test', 'ElementValue')).withMinMax(0));
   add(specs, gr);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addCodedElement(specs, ns);
-    addSimpleElement(specs, otherNS);
-    addForeignElementValue(specs, ns, otherNS);
-    addElementValue(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addCodedElement(specs, ns);
+  addSimpleElement(specs, otherNS);
+  addForeignElementValue(specs, ns, otherNS);
+  addElementValue(specs, ns);
   return gr;
 }
 
-function addGroupWithChoiceOfChoice(specs, ns, otherNS, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'GroupWithChoiceOfChoice'))
+function addGroupWithChoiceOfChoice(specs, ns, otherNS, isEntry=false) {
+  let gr = new mdl.DataElement(id(ns, 'GroupWithChoiceOfChoice'), isEntry)
     .withValue(new mdl.ChoiceValue().withMinMax(0,2)
       .withOption(new mdl.IdentifiableValue(id('shr.other.test', 'Simple')).withMinMax(1, 1))
       .withOption(new mdl.ChoiceValue().withMinMax(1, 1)
@@ -318,38 +317,35 @@ function addGroupWithChoiceOfChoice(specs, ns, otherNS, addSubElements=true) {
     .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1))
     .withField(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0, 1));
   add(specs, gr);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addCodedElement(specs, ns);
-    addSimpleElement(specs, otherNS);
-    addForeignElementValue(specs, ns, otherNS);
-    addElementValue(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addCodedElement(specs, ns);
+  addSimpleElement(specs, otherNS);
+  addForeignElementValue(specs, ns, otherNS);
+  addElementValue(specs, ns);
   return gr;
 }
 
-function addGroupPathClash(specs, ns, nsOther, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'GroupPathClash'))
+function addGroupPathClash(specs, ns, nsOther, isEntry=false) {
+  let gr = new mdl.DataElement(id(ns, 'GroupPathClash'), isEntry)
     .withDescription('It is a group of elements with clashing names')
     .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1))
     .withField(new mdl.IdentifiableValue(id('shr.other.test', 'Simple')).withMinMax(0, 1));
+  // Add subelements
   add(specs, gr);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleElement(specs, nsOther);
-  }
+  addSimpleElement(specs, ns);
+  addSimpleElement(specs, nsOther);
   return gr;
 }
 
-function addGroupDerivative(specs, ns, otherNS, addSubElements=true) {
-  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'))
+function addGroupDerivative(specs, ns, otherNS, isEntry=false) {
+  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'), isEntry)
     .withBasedOn(id('shr.test', 'Group'))
     .withDescription('It is a derivative of a group of elements')
     .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
   add(specs, gd);
-  if (addSubElements) {
-    addGroup(specs, ns, otherNS, addSubElements);
-  }
+  // Add subelements
+  addGroup(specs, ns, otherNS);
   return gd;
 }
 
@@ -362,10 +358,6 @@ function addSimpleElement(specs, ns, isEntry=false) {
   return de;
 }
 
-function addSimpleEntry(specs, ns) {
-  return addSimpleElement(specs, ns, true);
-}
-
 function addCodedElement(specs, ns, isEntry=false) {
   let de = new mdl.DataElement(id(ns, 'Coded'), isEntry)
     .withDescription('It is a coded element')
@@ -376,69 +368,62 @@ function addCodedElement(specs, ns, isEntry=false) {
   return de;
 }
 
-function addCodedEntry(specs, ns) {
-  return addCodedElement(specs, ns, true);
-}
-
-function addSimpleReference(specs, ns, addSubElement=true) {
-  let de = new mdl.DataElement(id(ns, 'SimpleReference'))
+function addSimpleReference(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'SimpleReference'), isEntry)
     .withDescription('It is a reference to a simple element')
     .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1)); // Reference to Entry
   add(specs, de);
-  if (addSubElement) {
-    addSimpleEntry(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns, true);
   return de;
 }
 
-function addReferenceChoice(specs, ns, otherNS, addSubElement=true) {
-  let ch = new mdl.DataElement(id(ns, 'ReferenceChoice'))
+function addReferenceChoice(specs, ns, otherNS, isEntry=false) {
+  let ch = new mdl.DataElement(id(ns, 'ReferenceChoice'), isEntry)
       .withDescription('It is a reference to one of a few types')
       .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
           .withOption(new mdl.IdentifiableValue(id(otherNS, 'Simple')).withMinMax(1, 1)) // Reference to Entry
           .withOption(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1)) // Reference to Entry
       );
   add(specs, ch);
-  if (addSubElement) {
-    addSimpleEntry(specs, otherNS);
-    addCodedEntry(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, otherNS, true);
+  addCodedElement(specs, ns, true);
   return ch;
 }
 
-function addTwoDeepElementValue(specs, ns, addSubElement=true) {
-  let de = new mdl.DataElement(id(ns, 'TwoDeepElementValue'))
+function addTwoDeepElementValue(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'TwoDeepElementValue'), isEntry)
     .withDescription('It is an element with a two-deep element value')
     .withValue(new mdl.IdentifiableValue(id(ns, 'ElementValue')).withMinMax(1, 1));
   add(specs, de);
-  if (addSubElement) {
-    addElementValue(specs, ns, true);
-  }
+  // Add subelements
+  addElementValue(specs, ns);
   return de;
 }
 
-function addElementValue(specs, ns, addSubElement=true) {
-  let de = new mdl.DataElement(id(ns, 'ElementValue'))
+function addElementValue(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'ElementValue'), isEntry)
     .withDescription('It is an element with an element value')
     .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1));
   add(specs, de);
-  if (addSubElement) {
-    addSimpleElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
   return de;
 }
 
-function addForeignElementValue(specs, ns, otherNS) {
-  let de = new mdl.DataElement(id(ns, 'ForeignElementValue'))
+function addForeignElementValue(specs, ns, otherNS, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'ForeignElementValue'), isEntry)
     .withDescription('It is an element with a foreign element value')
     .withValue(new mdl.IdentifiableValue(id(otherNS, 'Simple')).withMinMax(1, 1));
   add(specs, de);
+  // Add subelements
   addSimpleElement(specs, otherNS);
   return de;
 }
 
-function addChoice(specs, ns, addSubElements=true) {
-  let ch = new mdl.DataElement(id(ns, 'Choice'))
+function addChoice(specs, ns, isEntry=false) {
+  let ch = new mdl.DataElement(id(ns, 'Choice'), isEntry)
     .withDescription('It is an element with a choice')
     .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
       .withOption(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1))
@@ -448,14 +433,13 @@ function addChoice(specs, ns, addSubElements=true) {
       .withOption(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(1, 1))
     );
   add(specs, ch);
-  if (addSubElements) {
-    addCodedElement(specs, ns);
-  }
+  // Add subelements
+  addCodedElement(specs, ns);
   return ch;
 }
 
-function addChoiceOfChoice(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'ChoiceOfChoice'))
+function addChoiceOfChoice(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'ChoiceOfChoice'), isEntry)
     .withDescription('It is an element with a choice containing a choice')
     .withValue(new mdl.ChoiceValue().withMinMax(1, 1)
       .withOption(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1))
@@ -471,8 +455,8 @@ function addChoiceOfChoice(specs, ns) {
   return de;
 }
 
-function addTBDElement(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'NotDone'))
+function addTBDElement(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'NotDone'), isEntry)
       .withDescription('It is an unfinished element')
       .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
       .withValue(new mdl.TBD('An undetermined value.').withMinMax(1, 1))
@@ -483,8 +467,8 @@ function addTBDElement(specs, ns) {
   return de;
 }
 
-function addTBDElementDerivative(specs, ns, addSubElements=true) {
-  let de = new mdl.DataElement(id(ns, 'NotDoneDerivative'))
+function addTBDElementDerivative(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'NotDoneDerivative'), isEntry)
       .withBasedOn(new mdl.TBD('An undetermined parent.'))
       .withBasedOn(new mdl.TBD())
       .withBasedOn(id('shr.test', 'ValuelessElement'))
@@ -493,40 +477,38 @@ function addTBDElementDerivative(specs, ns, addSubElements=true) {
       .withValue(new mdl.TBD('An undetermined list value.').withMinMax(0))
       .withField(new mdl.TBD('An undetermined singular field.').withMinMax(1, 1));
   add(specs, de);
-  if (addSubElements) {
-    add(specs, new mdl.DataElement(id(ns, 'ValuelessElement'))
-        .withDescription('An element with no value.')
-        .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1)));
-    addSimpleElement(specs, ns);
-  }
+  // Add subelements
+  add(specs, new mdl.DataElement(id(ns, 'ValuelessElement'))
+      .withDescription('An element with no value.')
+      .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1)));
+  addSimpleElement(specs, ns);
   return de;
 }
 
-function addAbstractAndPlainElements(specs, ns, addSubElements=true) {
-  let gr = new mdl.DataElement(id(ns, 'AbstractAndPlainGroup'), false, true)
+function addAbstractAndPlainElements(specs, ns, isEntry=false) {
+  let gr = new mdl.DataElement(id(ns, 'AbstractAndPlainGroup'), isEntry, true)
       .withDescription('It is an abstract group of elements')
       .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Simple')).withMinMax(1, 1))
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Plain')).withMinMax(1, 1));
   add(specs, gr);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    add(specs, new mdl.DataElement(id(ns, 'Plain'))
-        .withDescription('It is not an entry element')
-        .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
-        .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1)));
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  add(specs, new mdl.DataElement(id(ns, 'Plain'))
+      .withDescription('It is not an entry element')
+      .withConcept(new mdl.Concept('http://foo.org', 'bar', 'Foobar'))
+      .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1)));
   return gr;
 }
 
-function addNestedCardConstrainedElement(specs, ns, addSubElements=true) {
+function addNestedCardConstrainedElement(specs, ns, isEntry=false) {
   let ov = new mdl.DataElement(id(ns, 'OptionalValue'))
     .withDescription('An element with an optional value.')
     .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(0, 1));
   let of = new mdl.DataElement(id(ns, 'OptionalField'))
     .withDescription('An element with an optional field.')
     .withField(new mdl.IdentifiableValue(id(ns, 'OptionalValue')).withMinMax(0, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedCardConstraint'))
+  let de = new mdl.DataElement(id(ns, 'NestedCardConstraint'), isEntry)
       .withDescription('It has a field with a nested card constraint.')
       .withField(new mdl.IdentifiableValue(id(ns, 'OptionalField'))
         .withMinMax(1, 1)
@@ -535,14 +517,14 @@ function addNestedCardConstrainedElement(specs, ns, addSubElements=true) {
   return de;
 }
 
-function addNestedListCardConstrainedElements(specs, ns, addSubElements=true) {
+function addNestedListCardConstrainedElements(specs, ns, isEntry=false) {
   let ov = new mdl.DataElement(id(ns, 'OptionalList'))
       .withDescription('An element with an optional list.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(0));
   let of = new mdl.DataElement(id(ns, 'ListField'))
       .withDescription('An element with a list field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'OptionalList')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedListCardConstraints'))
+  let de = new mdl.DataElement(id(ns, 'NestedListCardConstraints'), isEntry)
       .withDescription('It has a field with a nested card constraint on a list.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ListField'))
           .withMinMax(1, 1)
@@ -551,21 +533,20 @@ function addNestedListCardConstrainedElements(specs, ns, addSubElements=true) {
   return de;
 }
 
-function addTypeConstrainedElements(specs, ns, otherNS, addSubElements=true) {
+function addTypeConstrainedElements(specs, ns, otherNS, isEntry=false) {
   addSimpleChildElement(specs, ns);
-  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'))
+  let gd = new mdl.DataElement(id(ns, 'GroupDerivative'), isEntry)
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It is a derivative of a group of elements with type constraints.')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'))))
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementValue')).withMinMax(0).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), undefined, true)));
   add(specs, gd);
-  if (addSubElements) {
-    addGroup(specs, ns, otherNS, addSubElements);
-  }
+  // Add subelements
+  addGroup(specs, ns, otherNS);
   return gd;
 }
 
-function addTypeConstrainedElementsWithPath(specs, ns, addSubElements=true) {
+function addTypeConstrainedElementsWithPath(specs, ns, isEntry=false) {
   let ef = new mdl.DataElement(id(ns, 'ElementField'))
       .withDescription('It is an element with a field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1));
@@ -575,22 +556,21 @@ function addTypeConstrainedElementsWithPath(specs, ns, addSubElements=true) {
   let nf = new mdl.DataElement(id(ns, 'NestedField'))
       .withDescription('It is an element with a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1));
-  let cp = new mdl.DataElement(id(ns, 'ConstrainedPath'))
+  let cp = new mdl.DataElement(id(ns, 'ConstrainedPath'), isEntry)
       .withBasedOn(id('shr.test', 'NestedField'))
       .withDescription('It derives an element with a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
-  let cpni = new mdl.DataElement(id(ns, 'ConstrainedPathNoInheritance'))
+  let cpni = new mdl.DataElement(id(ns, 'ConstrainedPathNoInheritance'), isEntry)
       .withDescription('It has a new field with a nested constraint.')
       .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepElementField')).withMinMax(0, 1).withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'), [id(ns, 'ElementField'), id(ns, 'Simple')])));
   add(specs, ef, td, nf, cp, cpni);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addSimpleChildElement(specs, ns);
   return cp;
 }
 
-function addTypeConstrainedChoices(specs, ns, addSubElements=true) {
+function addTypeConstrainedChoices(specs, ns, isEntry=false) {
   let tcc = new mdl.DataElement(id(ns, 'TypeConstrainedChoice'))
     .withDescription('It is an element with a choice with a constraint.')
     .withField(new mdl.IdentifiableValue(id(ns, 'Choice')).withMinMax(1, 1)
@@ -602,39 +582,37 @@ function addTypeConstrainedChoices(specs, ns, addSubElements=true) {
   let td = new mdl.DataElement(id(ns, 'TwoDeepChoiceField'))
     .withDescription('It is an element with a a field with a choice.')
     .withField(new mdl.IdentifiableValue(id(ns, 'ChoiceValue')).withMinMax(0, 1));
-  let tccp = new mdl.DataElement(id(ns, 'TypeConstrainedChoiceWithPath'))
+  let tccp = new mdl.DataElement(id(ns, 'TypeConstrainedChoiceWithPath'), isEntry)
     .withDescription('It is an element with a choice on a field with a constraint.')
     .withField(new mdl.IdentifiableValue(id(ns, 'TwoDeepChoiceField')).withMinMax(0, 1)
       .withConstraint(new mdl.TypeConstraint(id(ns, 'Coded'), [id(ns, 'ChoiceValue'), id(ns, 'Choice')], true))
     );
   add(specs, tcc, cv, td, tccp);
-  if (addSubElements) {
-    addChoice(specs, ns);
-  }
+  // Add subelements
+  addChoice(specs, ns);
   return tccp;
 }
 
-function addTypeConstrainedReference(specs, ns, addSubElements=true) {
-  let de = new mdl.DataElement(id(ns, 'TypeConstrainedReference'))
+function addTypeConstrainedReference(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'TypeConstrainedReference'), isEntry)
     .withBasedOn(id(ns, 'SimpleReference'))
     .withDescription('It is an element a constraint on a reference.')
     .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(1, 1) // Reference to Entry
       .withConstraint(new mdl.TypeConstraint(id(ns, 'SimpleChild'))));
   add(specs, de);
-  if (addSubElements) {
-    addSimpleEntry(specs, ns);
-    addSimpleChildEntry(specs, ns);
-    addSimpleReference(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns, true);
+  addSimpleChildElement(specs, ns, true);
+  addSimpleReference(specs, ns);
   return de;
 }
 
-function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
+function addIncludesTypeConstraints(specs, ns, isEntry=false) {
   let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'IncludesTypesList'))
+  let de = new mdl.DataElement(id(ns, 'IncludesTypesList'), isEntry)
       .withDescription('An entry with a includes types constraints.')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
@@ -642,19 +620,18 @@ function addIncludesTypeConstraints(specs, ns, addSubElements=true) {
   );
   add(specs, sc2);
   add(specs, de);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addSimpleChildElement(specs, ns);
   return de;
 }
 
-function addIncludesTypeConstraintsWithZeroedOutType(specs, ns, addSubElements=true) {
+function addIncludesTypeConstraintsWithZeroedOutType(specs, ns, isEntry=false) {
   let sc2 = new mdl.DataElement(id(ns, 'SimpleChild2'))
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'IncludesTypesListWithZeroedOutType'))
+  let de = new mdl.DataElement(id(ns, 'IncludesTypesListWithZeroedOutType'), isEntry)
       .withDescription('An entry with a includes types constraints.')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0)
           .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1)))
@@ -662,14 +639,13 @@ function addIncludesTypeConstraintsWithZeroedOutType(specs, ns, addSubElements=t
   );
   add(specs, sc2);
   add(specs, de);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addSimpleChildElement(specs, ns);
   return de;
 }
 
-function addOnValueIncludesTypeConstraints(specs, ns, addSubElements=true) {
+function addOnValueIncludesTypeConstraints(specs, ns, isEntry=false) {
   let evl = new mdl.DataElement(id(ns, 'ElementValueList'), false, false)
       .withDescription('It is an element with a value that is a list of elements')
       .withValue(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0));
@@ -677,21 +653,20 @@ function addOnValueIncludesTypeConstraints(specs, ns, addSubElements=true) {
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'OnValueIncludesTypeConstraints'))
+  let de = new mdl.DataElement(id(ns, 'OnValueIncludesTypeConstraints'), isEntry)
       .withDescription('An entry with includes types constraints that are on the value of the field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementValueList')).withMinMax(0, 1)
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [], true))
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 2), [], true))
   );
   add(specs, evl, sc2, de);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addSimpleChildElement(specs, ns);
   return de;
 }
 
-function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
+function addNestedIncludesTypeConstraints(specs, ns, isEntry=false) {
   let efl = new mdl.DataElement(id(ns, 'ElementFieldList'), false, false)
       .withDescription('It is an element with a field that is a list of elements')
       .withField(new mdl.IdentifiableValue(id(ns, 'Simple')).withMinMax(0));
@@ -702,22 +677,21 @@ function addNestedIncludesTypeConstraints(specs, ns, addSubElements=true) {
       .withBasedOn(id(ns, 'Simple'))
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
-  let de = new mdl.DataElement(id(ns, 'NestedIncludesTypeConstraints'))
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesTypeConstraints'), isEntry)
       .withDescription('An entry with includes types constraints that are on a nested field.')
       .withField(new mdl.IdentifiableValue(id(ns, 'ElementFieldListContainer')).withMinMax(0, 1)
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild'), new mdl.Cardinality(0, 1), [id(ns, 'ElementFieldList'), id(ns, 'Simple')], false))
         .withConstraint(new mdl.IncludesTypeConstraint(id(ns, 'SimpleChild2'), new mdl.Cardinality(0, 2), [id(ns, 'ElementFieldList'), id(ns, 'Simple')], false))
   );
   add(specs, efl, eflc, sc2, de);
-  if (addSubElements) {
-    addSimpleElement(specs, ns);
-    addSimpleChildElement(specs, ns);
-  }
+  // Add subelements
+  addSimpleElement(specs, ns);
+  addSimpleChildElement(specs, ns);
   return de;
 }
 
-function addIncludesCodeConstraints(specs, ns) {
-  let de = new mdl.DataElement(id(ns, 'IncludesCodesList'))
+function addIncludesCodeConstraints(specs, ns, isEntry=false) {
+  let de = new mdl.DataElement(id(ns, 'IncludesCodesList'), isEntry)
     .withDescription('An entry with a includes codes constraint.')
     .withValue(new mdl.IdentifiableValue(pid('concept')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar')))
@@ -727,61 +701,58 @@ function addIncludesCodeConstraints(specs, ns) {
   return de;
 }
 
-function addNestedIncludesCodeConstraints(specs, ns, addSubElements=true) {
+function addNestedIncludesCodeConstraints(specs, ns, isEntry=false) {
   // NOTE: This tests a suspicious use case, as the includes code resolves to a 1..1 code.  It's the code's parent
   // that is actually a list -- so the iteration happens one level up.  This test is here because it reflects a real
   // use case in actual SHR definitions.
-  let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'))
+  let de = new mdl.DataElement(id(ns, 'NestedIncludesCodes'), isEntry)
     .withDescription('An entry with a nested includes codes constraint.')
     .withValue(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0)
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://foo.org', 'bar', 'Foobar'), [pid('concept')]))
       .withConstraint(new mdl.IncludesCodeConstraint(new mdl.Concept('http://boo.org', 'far', 'Boofar'), [pid('concept')]))
     );
   add(specs, de);
-  if (addSubElements) {
-    addCodedElement(specs, ns);
-  }
+  // Add subelements
+  addCodedElement(specs, ns);
   return de;
 }
 
-function addValueSetConstraints(specs, ns, otherNS, addSubElements=true) {
-  let gd = new mdl.DataElement(id(ns, 'NestedValueSetConstraints'))
+function addValueSetConstraints(specs, ns, otherNS, isEntry=false) {
+  let gd = new mdl.DataElement(id(ns, 'NestedValueSetConstraints'), isEntry)
       .withBasedOn(id('shr.test', 'Group'))
       .withDescription('It has valueset constraints on a field.')
       .withField(new mdl.IdentifiableValue(id('shr.test', 'Coded')).withMinMax(0, 1)
         .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('concept')]).withBindingStrength(mdl.REQUIRED))
   );
   add(specs, gd);
-  if (addSubElements) {
-    addGroup(specs, ns, otherNS, addSubElements);
-  }
+  // Add subelements
+  addGroup(specs, ns, otherNS);
   return gd;
 }
 
-function addValueSetChoiceConstraints(specs, ns, addSubElements=true) {
+function addValueSetChoiceConstraints(specs, ns, isEntry=false) {
   let cc = new mdl.DataElement(id(ns, 'CodedChoice'))
     .withDescription('An element with a choice of code fields.')
     .withValue(new mdl.ChoiceValue().withMinMax(0, 1)
       .withOption(new mdl.IdentifiableValue(id(ns, 'Coded')).withMinMax(1, 1))
       .withOption(new mdl.IdentifiableValue(pid('concept')).withMinMax(1, 1))
     );
-  let de = new mdl.DataElement(id(ns, 'ChoiceValueSetConstraint'))
+  let de = new mdl.DataElement(id(ns, 'ChoiceValueSetConstraint'), isEntry)
     .withDescription('It has valueset constraints on a choice field.')
     .withField(new mdl.IdentifiableValue(id(ns, 'CodedChoice')).withMinMax(0, 1)
       .withConstraint(new mdl.ValueSetConstraint('http://standardhealthrecord.org/test/vs/Coded2', [pid('concept')]).withBindingStrength(mdl.PREFERRED))
     );
   add(specs, cc, de);
-  if (addSubElements) {
-    addCodedElement(specs, ns);
-  }
+  // Add subelements
+  addCodedElement(specs, ns);
   return de;
 }
 
-function addConstConstraints(specs, ns, otherNS, addSubElements=true) {
+function addConstConstraints(specs, ns, otherNS, isEntry=false) {
   let bl = new mdl.DataElement(id(ns, 'Bool'), false)
     .withDescription('A boolean element.')
       .withValue(new mdl.IdentifiableValue(pid('boolean')).withMinMax(0, 1));
-  let cc = new mdl.DataElement(id(ns, 'BooleanAndCodeConstraints'))
+  let cc = new mdl.DataElement(id(ns, 'BooleanAndCodeConstraints'), isEntry)
     .withBasedOn(id('shr.test', 'Group'))
     .withDescription('It has boolean and code constraints.')
     .withValue(new mdl.IdentifiableValue(pid('boolean')).withMinMax(1, 1).withConstraint(new mdl.BooleanConstraint(true)))
@@ -791,15 +762,14 @@ function addConstConstraints(specs, ns, otherNS, addSubElements=true) {
       .withConstraint(new mdl.BooleanConstraint(false)));
 
   add(specs, bl, cc);
-  if (addSubElements) {
-    addGroup(specs, ns, otherNS, addSubElements);
-  }
+  // Add subelements
+  addGroup(specs, ns, otherNS);
   return cc;
 }
 
-function addFixedCodeExtravaganza(specs, ns, addSubElements=true) {
+function addFixedCodeExtravaganza(specs, ns, isEntry=false) {
   // NOTE: This is considerably less interesting w/ the elimination of Coding and CodeableConcept
-  const fce = new mdl.DataElement(id(ns, 'FixedCodeExtravaganza'), false, false)
+  const fce = new mdl.DataElement(id(ns, 'FixedCodeExtravaganza'), isEntry)
     .withDescription('An element with all sorts of fixed codes.')
     .withValue(new mdl.ChoiceValue().withMinMax(0, 1)
       .withOption(new mdl.IdentifiableValue(pid('Coded')).withMinMax(1, 1)
@@ -816,10 +786,9 @@ function addFixedCodeExtravaganza(specs, ns, addSubElements=true) {
       .withConstraint(new mdl.CodeConstraint(new mdl.Concept('http://foo4.org', 'bar4', 'Foobar4'), [pid('concept')]))
     );
   add(specs, fce);
-  if (addSubElements) {
-    addCodedElement(specs, ns);
-  }
-
+  // Add subelements
+  addCodedElement(specs, ns);
+  return fce;
 }
 
 function addSimpleChildElement(specs, ns, isEntry=false) {
@@ -828,10 +797,6 @@ function addSimpleChildElement(specs, ns, isEntry=false) {
       .withDescription('A derivative of the simple type.')
       .withValue(new mdl.IdentifiableValue(pid('string')).withMinMax(1, 1));
   add(specs, sc1);
-}
-
-function addSimpleChildEntry(specs, ns) {
-  addSimpleChildElement(specs, ns, true);
 }
 
 function add(specs, ...dataElements) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
-    "shr-models": "^6.0.0-beta.1"
+    "shr-models": "^6.0.0-beta.2"
   },
   "dependencies": {
     "fs-extra": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
-    "shr-models": "^6.0.0-beta.2"
+    "shr-models": "^6.0.0"
   },
   "dependencies": {
     "fs-extra": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-test-helpers",
-  "version": "5.2.2",
+  "version": "6.0.0-beta.1",
   "description": "Re-usable classes and functions for testing SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
-    "shr-models": "^5.5.0"
+    "shr-models": "^6.0.0-beta.1"
   },
   "dependencies": {
     "fs-extra": "^5.0.0"


### PR DESCRIPTION
Updates to the tests needed to support CIMPL6.  The two most significant changes to the model are:

* Replaced `code`, `Coding`, and `CodeableConcept` with new `concept` primitive
* Removed `RefValue` in favor of using a field's "entry-ness" to determine if it should be a reference

This is used by unit tests of other modules.  It's inherently tested by testing those other modules.

Marking as a DRAFT PR because all versions will need to be bumped to non-beta versions upon approval.